### PR TITLE
Fix Render Jekyll build gem path conflict

### DIFF
--- a/.bundle/config
+++ b/.bundle/config
@@ -1,2 +1,0 @@
----
-BUNDLE_PATH: "vendor/bundle"

--- a/.gitignore
+++ b/.gitignore
@@ -5,9 +5,8 @@ _site/
 .jekyll-metadata
 
 
-### Bundler (vendor install; keep path in tracked config)
-.bundle/*
-!.bundle/config
+### Bundler (local vendor install; path set via `make gems`)
+.bundle/
 vendor/
 
 

--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,7 @@ help:
 setup: gems npm
 
 gems:
+	bundle config set --local path vendor/bundle
 	bundle install
 
 npm:

--- a/render.yaml
+++ b/render.yaml
@@ -2,6 +2,6 @@ services:
   - type: web
     name: site-name-here
     runtime: static
-    buildCommand: bundle install && npm ci && bundle exec jekyll build
+    buildCommand: bundle install --without development test && npm ci && bundle exec jekyll build
     staticPublishPath: _site
     pullRequestPreviewsEnabled: true


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Render builds failed with:

```
can't find gem jekyll (>= 0.a) with executable jekyll (Gem::GemNotFoundException)
```

The committed `.bundle/config` set `BUNDLE_PATH` to `vendor/bundle`, but Render installs gems into `/opt/render/project/.gems`. That mismatch left the `jekyll` binstub unable to locate the installed gem.

## Solution

- Remove the tracked `.bundle/config` so Render uses its default gem install path
- Configure `vendor/bundle` locally via `make gems` for development
- Ignore `.bundle/` entirely in `.gitignore`
- Keep an explicit `bundle exec jekyll build` in `render.yaml`

## Dashboard note

If the Render service was created manually (not via Blueprint), update the build command in the Dashboard to match `render.yaml`:

```
bundle install --without development test && npm ci && bundle exec jekyll build
```

The failing deploy log showed `jekyll build` without `bundle exec`, which suggests the Dashboard build command may differ from the Blueprint.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f0261231-2ab4-4704-907f-49b88657dee6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f0261231-2ab4-4704-907f-49b88657dee6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

